### PR TITLE
fix(SmartScroll): allowuseoftextinputs

### DIFF
--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -162,11 +162,25 @@ const SmartScrollProvider = ({ children }: { children: React.ReactNode }) => {
 
 export const useSmartScrollContext = () => {
   const context = React.useContext(SmartScrollContext);
+  const scrollY = useSharedValue(0);
+  const wrapperRef = React.useRef<View>(null);
+  const scrollRef = useAnimatedRef<Animated.ScrollView>();
 
   if (!context) {
-    throw new Error(
-      'Component must be wrapped in a SmartScrollProvider. Please ensure the provider is included.'
-    );
+    return {
+      scrollRef,
+      scrollY: scrollY,
+      isReady: false,
+      wrapperRef,
+      wrapperOffset: 0,
+      setWrapperOffset: () => null,
+      elements: {},
+      setElements: () => null,
+      inputs: {},
+      setInputs: () => null,
+      currentFocus: undefined,
+      clearFocus: () => null,
+    };
   }
 
   return context;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,5 +9,5 @@ export const MagicScroll = {
   ViewWrapper,
   TextInput,
   withSmartScroll,
-  SmartScrollView,
+  ChainingProvider: SmartScrollView,
 };


### PR DESCRIPTION
- Allow the usage of MagicTextInput outside of a MagicScrollview
- Renamed export `SmartScrollView` to `ChainingProvider` as it will be mostly used for this use case (I might be wrong)